### PR TITLE
[FIX] itm: random password doesn't work as expected

### DIFF
--- a/itm/__manifest__.py
+++ b/itm/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "IT Infrastructure Management",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.0.2",
     "license": "AGPL-3",
     "category": "IT Infrastructure Management",
     "summary": """IT Assets, Credentials, Backups, Applications.""",

--- a/itm/models/access.py
+++ b/itm/models/access.py
@@ -41,8 +41,7 @@ class ItAccess(models.Model):
 
     def get_random_password(self):
         for access in self:
-            token = self.encrypt_string(self.get_random_string())
-            access.password = token
+            access.password = self.get_random_string()
 
     def get_urlsafe_key(self):
 

--- a/itm/tests/test_access.py
+++ b/itm/tests/test_access.py
@@ -39,3 +39,15 @@ class TestAccess(TransactionCase):
         self.assertEqual("123", self._decrypt(cred.password))
         cred.write({"password": "456"})
         self.assertEqual("456", self._decrypt(cred.password))
+
+    def test_random_password(self):
+        """Random password isn't mangled"""
+
+        # Not sure there's a way to test randomness. Just test that
+        # it's the expected length.
+        #
+        cred = self.ItAccess.create({"name": "a", "site_id": self.defaultSite.id})
+        self.assertFalse(cred.password)
+        cred.get_random_password()
+        strRandom = self.ItAccess.decrypt_password_as_string(cred.id)
+        self.assertEqual(16, len(strRandom))


### PR DESCRIPTION
Generated random password was being doubly encrypted. First by
the get_random_password() method itself, and a second time
when the already encrypted url-safe string was written to
the database.

Fixes: #9