### PR TITLE
[FIX][14.0] itm: fix default value of user_id field

### DIFF
--- a/itm/README.rst
+++ b/itm/README.rst
@@ -35,6 +35,10 @@ Known issues / Roadmap
 Changelog
 =========
 
+14.0.1.1.5 (2021-10-30)
+~~~~~~~~~~~~~~~~~~~~~~~
+* [FIX] An unhandled exception when creating a worklog from Equipment form view
+
 14.0.1.1.4 (2021-10-30)
 ~~~~~~~~~~~~~~~~~~~~~~~
 * [IMP] Add ability to register components (network cards, SATA controllers, etc) and associate them with assets

--- a/itm/__manifest__.py
+++ b/itm/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "IT Infrastructure Management",
-    "version": "14.0.1.1.4",
+    "version": "14.0.1.1.5",
     "license": "AGPL-3",
     "category": "IT Infrastructure Management",
     "summary": """IT Assets, Credentials, Backups, Applications.""",

--- a/itm/models/equipment_worklog.py
+++ b/itm/models/equipment_worklog.py
@@ -34,5 +34,5 @@ class ItEquipmentWorklog(models.Model):
     spent_time = fields.Float()
     equipment_id = fields.Many2one("itm.equipment", "Asset", ondelete="cascade")
     user_id = fields.Many2one(
-        "res.users", "User", required=True, default=lambda self: self.env.user_id.id
+        "res.users", "User", required=True, default=lambda self: self.env.user.id
     )

--- a/itm/readme/HISTORY.rst
+++ b/itm/readme/HISTORY.rst
@@ -1,3 +1,7 @@
+14.0.1.1.5 (2021-10-30)
+~~~~~~~~~~~~~~~~~~~~~~~
+* [FIX] An unhandled exception when creating a worklog from Equipment form view
+
 14.0.1.1.4 (2021-10-30)
 ~~~~~~~~~~~~~~~~~~~~~~~
 * [IMP] Add ability to register components (network cards, SATA controllers, etc) and associate them with assets

--- a/itm/tests/__init__.py
+++ b/itm/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_access
 from . import test_component
+from . import test_worklog

--- a/itm/tests/test_worklog.py
+++ b/itm/tests/test_worklog.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 TREVI Software
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo.tests import common
+
+
+class TestEquipmentComponent(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestEquipmentComponent, cls).setUpClass()
+
+        cls.Equipment = cls.env["itm.equipment"]
+        cls.ItSite = cls.env["itm.site"]
+        cls.Partner = cls.env["res.partner"]
+        cls.Log = cls.env["itm.equipment.worklog"]
+
+        cls.defaultSite = cls.ItSite.create({"name": "site"})
+        cls.defaultPartner = cls.Partner.create(
+            {
+                "name": "Partner A",
+                "email": "a@example.org",
+            }
+        )
+        cls.equipment = cls.Equipment.create(
+            {
+                "name": "My Equipment",
+                "partner_id": cls.defaultPartner.id,
+                "site_id": cls.defaultSite.id,
+            }
+        )
+
+    def test_fix_issue17(self):
+        """Creating worklog entry doesn't cause an exception"""
+
+        try:
+            self.Log.default_get(["user_id"])
+        except AttributeError:
+            self.fail("Unexpected failure")


### PR DESCRIPTION
Trying to create a worklog from the equipment form view caused an
exception because of self.env.user was misspelled self.env.user_id.

Fixes #17